### PR TITLE
fix: Update Log4J version to 2.15.0 to patch CVE-2021-44228 critical)…

### DIFF
--- a/ECommerce/pom.xml
+++ b/ECommerce/pom.xml
@@ -16,6 +16,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -66,12 +67,12 @@
 		<dependency>
 		  <groupId>org.apache.logging.log4j</groupId>
 		  <artifactId>log4j-api</artifactId>
-		  <version>2.6.1</version>
+		  <version>2.15.0</version>
 		</dependency>
 		<dependency>
 		  <groupId>org.apache.logging.log4j</groupId>
 		  <artifactId>log4j-core</artifactId>
-		  <version>2.6.1</version>
+		  <version>2.15.0</version>
 		</dependency>
 	
 	</dependencies>


### PR DESCRIPTION
fix: Update Log4J version to 2.15.0 to patch CVE-2021-44228 critical) vulnerability